### PR TITLE
Added negative scenarios for delete operation in PetStore API

### DIFF
--- a/API/Features/PetStoreNegativeDelete.feature
+++ b/API/Features/PetStoreNegativeDelete.feature
@@ -1,0 +1,11 @@
+Feature: PetStore API Negative Delete Operations
+
+  Scenario: Delete a pet with an invalid ID
+    Given I have an invalid pet ID
+    When I send a DELETE request to the PetStore API
+    Then I should receive a 404 Not Found response
+
+  Scenario: Delete a pet with a non-existent ID
+    Given I have a non-existent pet ID
+    When I send a DELETE request to the PetStore API
+    Then I should receive a 404 Not Found response

--- a/API/StepDefinitions/PetStoreNegativeDeleteSteps.cs
+++ b/API/StepDefinitions/PetStoreNegativeDeleteSteps.cs
@@ -1,0 +1,45 @@
+using TechTalk.SpecFlow;
+using NUnit.Framework;
+using RestSharp;
+using API.Clients;
+
+namespace API.StepDefinitions
+{
+    [Binding]
+    public class PetStoreNegativeDeleteSteps
+    {
+        private readonly PetStoreApiClient _client;
+        private IRestResponse _response;
+        private string _invalidPetId;
+        private string _nonExistentPetId;
+
+        public PetStoreNegativeDeleteSteps(PetStoreApiClient client)
+        {
+            _client = client;
+        }
+
+        [Given("I have an invalid pet ID")]
+        public void GivenIHaveAnInvalidPetID()
+        {
+            _invalidPetId = "invalid-id";
+        }
+
+        [Given("I have a non-existent pet ID")]
+        public void GivenIHaveANonExistentPetID()
+        {
+            _nonExistentPetId = "999999";
+        }
+
+        [When("I send a DELETE request to the PetStore API")]
+        public void WhenISendADELETERequestToThePetStoreAPI()
+        {
+            _response = _client.DeletePet(_invalidPetId ?? _nonExistentPetId);
+        }
+
+        [Then("I should receive a 404 Not Found response")]
+        public void ThenIShouldReceiveA404NotFoundResponse()
+        {
+            Assert.AreEqual(404, (int)_response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
Added two negative scenarios for the delete operation in the PetStore API. These scenarios cover cases where the pet ID is invalid or non-existent. The corresponding step definitions have also been implemented.