### PR TITLE
Added negative scenarios for PetStore API delete operation

### DIFF
--- a/API/Features/NewPetStoreDeleteNegative.feature
+++ b/API/Features/NewPetStoreDeleteNegative.feature
@@ -1,0 +1,22 @@
+@PetStoreAPI @Regression @APITesting
+Feature: Pet Store API Delete Operations - Negative Scenarios
+  As an API consumer
+  I want to validate negative scenarios for deleting pets
+  So that I can ensure proper error handling and responses
+
+Background:
+	Given the PetStore API is available and accessible
+
+@DeletePet @NegativeScenario
+Scenario: Attempt to delete a pet with a non-existent ID
+	Given I have a non-existent pet ID
+	When I send a DELETE request to delete the pet
+	Then the response status code should be 404
+	And the response message should indicate that the pet was not found
+
+@DeletePet @NegativeScenario
+Scenario: Attempt to delete a pet with an invalid ID format
+	Given I have an invalid pet ID format
+	When I send a DELETE request to delete the pet
+	Then the response status code should be 400
+	And the response message should indicate a bad request due to invalid ID format

--- a/API/StepDefinitions/NewPetStoreDeleteNegativeSteps.cs
+++ b/API/StepDefinitions/NewPetStoreDeleteNegativeSteps.cs
@@ -1,0 +1,65 @@
+using TechTalk.SpecFlow;
+using AutomationFramework.API.BusinessLogic;
+using AutomationFramework.Core.Config;
+using RestSharp;
+using FluentAssertions;
+using Serilog;
+
+namespace AutomationFramework.API.StepDefinitions
+{
+    [Binding]
+    public class NewPetStoreDeleteNegativeSteps
+    {
+        private readonly PetBusinessLogic _petBusinessLogic;
+        private RestResponse _response;
+        private ScenarioContext _scenarioContext;
+        public NewPetStoreDeleteNegativeSteps(ScenarioContext scenarioContext)
+        {
+            var baseUrl = ConfigManager.GetConfigValue<string>("ApiBaseUrl");
+            _scenarioContext = scenarioContext;
+            _petBusinessLogic = new PetBusinessLogic(baseUrl);
+        }
+
+        [Given(@"I have a non-existent pet ID")]
+        public void GivenIHaveANonExistentPetID()
+        {
+            _scenarioContext["PetID"] = 999999;
+            Log.Information("Using a non-existent pet ID: 999999");
+        }
+
+        [Given(@"I have an invalid pet ID format")]
+        public void GivenIHaveAnInvalidPetIDFormat()
+        {
+            _scenarioContext["PetID"] = "invalid-id";
+            Log.Information("Using an invalid pet ID format: invalid-id");
+        }
+
+        [When(@"I send a DELETE request to delete the pet")]
+        public void WhenISendADELETERequestToDeleteThePet()
+        {
+            var petId = _scenarioContext["PetID"].ToString();
+            _response = _petBusinessLogic.DeletePet(petId);
+        }
+
+        [Then(@"the response status code should be (.*)")]
+        public void ThenTheResponseStatusCodeShouldBe(int expectedStatusCode)
+        {
+            _response.StatusCode.Should().Be((System.Net.HttpStatusCode)expectedStatusCode);
+            Log.Information($"Verified response status code: {_response.StatusCode}");
+        }
+
+        [Then(@"the response message should indicate that the pet was not found")]
+        public void ThenTheResponseMessageShouldIndicateThatThePetWasNotFound()
+        {
+            _response.Content.Should().Contain("Pet not found");
+            Log.Information("Verified response message: Pet not found");
+        }
+
+        [Then(@"the response message should indicate a bad request due to invalid ID format")]
+        public void ThenTheResponseMessageShouldIndicateABadRequestDueToInvalidIDFormat()
+        {
+            _response.Content.Should().Contain("Invalid ID format");
+            Log.Information("Verified response message: Invalid ID format");
+        }
+    }
+}


### PR DESCRIPTION
Implemented two negative scenarios for the delete operation in the PetStore API:
1. Attempt to delete a pet with a non-existent ID, expecting a 404 response.
2. Attempt to delete a pet with an invalid ID format, expecting a 400 response.

Feature file: API/Features/NewPetStoreDeleteNegative.feature
Step definitions: API/StepDefinitions/NewPetStoreDeleteNegativeSteps.cs